### PR TITLE
dont obscure street labels with route line

### DIFF
--- a/maps.earth/Models/MapContents.swift
+++ b/maps.earth/Models/MapContents.swift
@@ -212,18 +212,15 @@ struct MapTrip: MapContent {
       return
     }
 
-    // Insert the route line behind the annotation layer to keep the "end" markers above the routes.
-    //     identifier = com.mapbox.annotations.points; sourceIdentifier = com.mapbox.annotations; sourceLayerIdentifier = com.mapbox.annotations.points
-    let annotationsLayer = style.layers.first(where: {
-      $0.identifier == "com.mapbox.annotations.points"
-    })
+    // Insert the route line behind the symbol layer to keep the routes below the "end" markers and street labels
+    let firstSymbolLayer = style.firstSymbolLayer
 
     for legLayer in tripLayers.legLayers {
       style.addSource(legLayer.source)
-      if let annotationsLayer = annotationsLayer {
-        style.insertLayer(legLayer.styleLayer, below: annotationsLayer)
+      if let firstSymbolLayer {
+        style.insertLayer(legLayer.styleLayer, below: firstSymbolLayer)
       } else {
-        assertionFailure("couldn't find annotationsLayer layer. Did maplibre change their API?")
+        assertionFailure("couldn't find firstSymbolLayer layer. Did maplibre change their API?")
         style.addLayer(legLayer.styleLayer)
       }
     }

--- a/maps.earth/Views/MapView.swift
+++ b/maps.earth/Views/MapView.swift
@@ -135,7 +135,7 @@ func add3DBuildingsLayer(mapView: MLNMapView) {
 
   assert(style.layers.first { $0.identifier == "subtle_3d_buildings" } == nil)
 
-  guard let source = (style.sources.first { $0.identifier == "openmaptiles" }) else {
+  guard let source = style.openMapTilesSource else {
     assertionFailure("openmaptiles source was unexpectedly missing")
     return
   }
@@ -149,11 +149,11 @@ func add3DBuildingsLayer(mapView: MLNMapView) {
   buildingsLayer.fillExtrusionBase = NSExpression(forKeyPath: "render_min_height")
   buildingsLayer.fillExtrusionOpacity = NSExpression(forConstantValue: 0.6)
 
-  guard let symbolLayer = (style.layers.first { $0 is MLNSymbolStyleLayer }) else {
+  guard let firstSymbolLayer = style.firstSymbolLayer else {
     assertionFailure("symbolLayer was unexpectedly nil")
     return
   }
-  style.insertLayer(buildingsLayer, below: symbolLayer)
+  style.insertLayer(buildingsLayer, below: firstSymbolLayer)
 }
 
 extension MapView: UIViewRepresentable {
@@ -646,6 +646,20 @@ func debugString(_ trackingMode: MLNUserTrackingMode) -> String {
 extension Bounds {
   var mlnBounds: MLNCoordinateBounds {
     MLNCoordinateBounds(sw: self.min.asCoordinate, ne: self.max.asCoordinate)
+  }
+}
+
+extension MLNStyle {
+  var openMapTilesSource: MLNSource? {
+    guard let source = (self.sources.first { $0.identifier == "openmaptiles" }) else {
+      assertionFailure("openmaptiles source was unexpectedly missing")
+      return nil
+    }
+    return source
+  }
+
+  var firstSymbolLayer: MLNSymbolStyleLayer? {
+    self.layers.compactMap { $0 as? MLNSymbolStyleLayer }.first
   }
 }
 


### PR DESCRIPTION
Previously the route lines in the trip planner were drawn over the street labels, so you couldn't read the names of the streets.