### PR TITLE
More useful UI after completing trip

### DIFF
--- a/maps.earth.xcodeproj/project.pbxproj
+++ b/maps.earth.xcodeproj/project.pbxproj
@@ -817,7 +817,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9;
+				MARKETING_VERSION = 1.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "earth.maps.maps-earth";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;
@@ -851,7 +851,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.9;
+				MARKETING_VERSION = 1.10;
 				PRODUCT_BUNDLE_IDENTIFIER = "earth.maps.maps-earth";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_EMIT_LOC_STRINGS = YES;

--- a/maps.earth/Views/FrontPageSearch.swift
+++ b/maps.earth/Views/FrontPageSearch.swift
@@ -30,7 +30,8 @@ struct FrontPageSearch: View {
     ).sheet(item: $selectedPlace) { place in
       PlaceDetailSheet(
         place: place, tripPlan: tripPlan, presentationDetent: $placeDetailsDetent,
-        onClose: { selectedPlace = nil }
+        onClose: { selectedPlace = nil },
+        didCompleteTrip: { didDismissSearch() }  // better name for didDismissSearch
       )
       // This is arguably useful.
       // Usually I just want to swipe down to get a better look at the map without closing out

--- a/maps.earth/Views/MENavigationView.swift
+++ b/maps.earth/Views/MENavigationView.swift
@@ -195,7 +195,7 @@ struct MENavigationView: View {
   var route: FerrostarCoreFFI.Route
   //  let initialLocation: CLLocation
   let styleURL: URL
-  let stopNavigation: () -> Void
+  let stopNavigation: (_ didComplete: Bool) -> Void
   let destination: MapboxDirections.Waypoint
   let locationProvider: LocationProviding
 
@@ -208,7 +208,7 @@ struct MENavigationView: View {
     route: MapboxDirections.Route,
     travelMode: TravelMode,
     measurementSystem: MeasurementSystem,
-    stopNavigation: @escaping () -> Void
+    stopNavigation: @escaping (_ didComplete: Bool) -> Void
   ) {
     self.destination = route.legs.last!.destination
     self.route = FerrostarCoreFFI.Route(mapboxRoute: route)
@@ -285,7 +285,7 @@ struct MENavigationView: View {
       onStyleLoaded: { style in
         add3DBuildingsLayer(style: style)
       },
-      onTapExit: { stopNavigation() },
+      onTapExit: stopNavigation,
       makeMapContent: {
         let source = ShapeSource(identifier: "userLocation") {
           // Demonstrate how to add a dynamic overlay;

--- a/maps.earth/Views/PlaceDetail.swift
+++ b/maps.earth/Views/PlaceDetail.swift
@@ -16,6 +16,7 @@ struct PlaceDetailSheet: View {
   @ObservedObject var tripPlan: TripPlan
   @Binding var presentationDetent: PresentationDetent
   var onClose: () -> Void
+  var didCompleteTrip: () -> Void
 
   @EnvironmentObject var userLocationManager: UserLocationManager
 
@@ -43,7 +44,8 @@ struct PlaceDetailSheet: View {
     ) {
       ScrollView {
         PlaceDetail(
-          place: place, tripPlan: tripPlan,
+          place: place,
+          tripPlan: tripPlan,
           didSelectNavigateTo: { place in
             tripPlan.navigateTo = place
             if let mostRecentUserLocation = self.userLocationManager
@@ -51,7 +53,9 @@ struct PlaceDetailSheet: View {
             {
               tripPlan.navigateFrom = Place(currentLocation: mostRecentUserLocation)
             }
-          })
+          },
+          didCompleteTrip: didCompleteTrip
+        )
       }
       // This is arguably useful.
       // Usually I just want to swipe down to get a better look at the map without closing out
@@ -65,6 +69,7 @@ struct PlaceDetail: View {
   var place: Place
   @ObservedObject var tripPlan: TripPlan
   var didSelectNavigateTo: (Place) -> Void
+  var didCompleteTrip: () -> Void
 
   var body: some View {
     let isShowingDirections = Binding(
@@ -85,7 +90,7 @@ struct PlaceDetail: View {
         .background(.blue)
         .cornerRadius(4)
         .sheet(isPresented: isShowingDirections) {
-          TripPlanSheetContents(tripPlan: tripPlan)
+          TripPlanSheetContents(tripPlan: tripPlan, didCompleteTrip: didCompleteTrip)
             .interactiveDismissDisabled()
         }
         Spacer()
@@ -121,6 +126,6 @@ struct PlaceDetail: View {
   Text("").sheet(isPresented: .constant(true)) {
     PlaceDetailSheet(
       place: FixtureData.places[.zeitgeist], tripPlan: TripPlan(),
-      presentationDetent: .constant(.medium), onClose: {})
+      presentationDetent: .constant(.medium), onClose: {}, didCompleteTrip: {})
   }
 }

--- a/maps.earth/Views/TripPlanView.swift
+++ b/maps.earth/Views/TripPlanView.swift
@@ -120,6 +120,7 @@ struct TripPlanView: View {
   var searcher = TripSearchManager()
   @State var showSteps: Bool
   @State var tripDate: TripDateMode = .departNow
+  var didCompleteTrip: () -> Void
 
   var body: some View {
     let showRouteSheet = Binding(
@@ -186,7 +187,15 @@ struct TripPlanView: View {
           route: route,
           travelMode: tripPlan.mode,
           measurementSystem: searcher.measurementSystem,
-          stopNavigation: { tripPlan.selectedRoute = nil }
+          stopNavigation: { didComplete in
+            tripPlan.selectedRoute = nil
+            if didComplete {
+              self.tripPlan.selectedTrip = nil
+              self.tripPlan.navigateTo = nil
+              self.tripPlan.navigateFrom = nil
+              self.didCompleteTrip()
+            }
+          }
         )
       } else {
         let _ = assertionFailure("showing route sheet without a successful route.")
@@ -266,6 +275,7 @@ struct TripSearchManager {
 struct TripPlanSheetContents: View {
   @ObservedObject var tripPlan: TripPlan
   @State var showSteps: Bool = false
+  var didCompleteTrip: () -> Void
 
   var body: some View {
     SheetContents(
@@ -273,7 +283,7 @@ struct TripPlanSheetContents: View {
     ) {
       GeometryReader { geometry in
         ScrollView {
-          TripPlanView(tripPlan: tripPlan, showSteps: showSteps)
+          TripPlanView(tripPlan: tripPlan, showSteps: showSteps, didCompleteTrip: didCompleteTrip)
             .padding(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
             .frame(minHeight: geometry.size.height)
         }
@@ -285,14 +295,14 @@ struct TripPlanSheetContents: View {
 #Preview("Walk Trips") {
   let tripPlan = FixtureData.walkTripPlan
   return Text("").sheet(isPresented: .constant(true)) {
-    TripPlanSheetContents(tripPlan: tripPlan)
+    TripPlanSheetContents(tripPlan: tripPlan, didCompleteTrip: {})
   }
 }
 
 #Preview("Transit Trips") {
   let tripPlan = FixtureData.transitTripPlan
   return Text("").sheet(isPresented: .constant(true)) {
-    TripPlanSheetContents(tripPlan: tripPlan)
+    TripPlanSheetContents(tripPlan: tripPlan, didCompleteTrip: {})
   }
 }
 
@@ -301,27 +311,27 @@ struct TripPlanSheetContents: View {
   let tripPlan = FixtureData.tripPlan
   tripPlan.trips = .failure(FixtureData.bikeTripError)
   return Text("").sheet(isPresented: .constant(true)) {
-    TripPlanSheetContents(tripPlan: tripPlan)
+    TripPlanSheetContents(tripPlan: tripPlan, didCompleteTrip: {})
   }
 }
 
 #Preview("Steps") {
   let tripPlan = FixtureData.tripPlan
   return Text("").sheet(isPresented: .constant(true)) {
-    TripPlanSheetContents(tripPlan: tripPlan, showSteps: true)
+    TripPlanSheetContents(tripPlan: tripPlan, showSteps: true, didCompleteTrip: {})
   }
 }
 
 #Preview("Only 'to' selected") {
   let tripPlan = TripPlan(to: FixtureData.places[.zeitgeist])
   return Text("").sheet(isPresented: .constant(true)) {
-    TripPlanSheetContents(tripPlan: tripPlan)
+    TripPlanSheetContents(tripPlan: tripPlan, didCompleteTrip: {})
   }
 }
 
 #Preview("Only 'from' selected") {
   let tripPlan = TripPlan(from: FixtureData.places[.dubsea])
   return Text("").sheet(isPresented: .constant(true)) {
-    TripPlanSheetContents(tripPlan: tripPlan)
+    TripPlanSheetContents(tripPlan: tripPlan, didCompleteTrip: {})
   }
 }


### PR DESCRIPTION
Previously, after completing a trip, you'd just end up at the prior step, ready to start the same trip again.

But you've just completed that trip - no need to restart it.

So instead we now pop you to the "Detail" sheet of the trip arrival
screen.

And also clear the search field.